### PR TITLE
Fix deprecations with new signature of League\OAuth2's AbstractProvider

### DIFF
--- a/src/Provider/Okta.php
+++ b/src/Provider/Okta.php
@@ -4,6 +4,7 @@ namespace Foxworth42\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use Psr\Http\Message\ResponseInterface;
@@ -63,6 +64,9 @@ class Okta extends AbstractProvider
         return parent::getAuthorizationParameters($options);
     }
 
+    /**
+     * @retrun array
+     **/
     protected function getDefaultScopes()
     {
         return [
@@ -72,11 +76,17 @@ class Okta extends AbstractProvider
         ];
     }
 
+    /**
+     * @retrun string
+     **/
     protected function getScopeSeparator()
     {
         return ' ';
     }
 
+    /**
+     * @retrun void
+     **/
     protected function checkResponse(ResponseInterface $response, $data)
     {
         // @codeCoverageIgnoreStart
@@ -96,6 +106,9 @@ class Okta extends AbstractProvider
         throw new IdentityProviderException($error, $code, $data);
     }
 
+    /**
+     * @retrun ResourceOwnerInterface
+     **/
     protected function createResourceOwner(array $response, AccessToken $token)
     {
         $user = new OktaUser($response);


### PR DESCRIPTION
fix few deprecations like 

```
Method "League\OAuth2\Client\Provider\AbstractProvider::getDefaultScopes()" might add "array" as a native return type declaration in the future. Do the same in child class "Foxworth42\OAuth2\Client\Provider\Okta" now to avoid errors or add an explicit @return annotation to suppress this message.
```

