### PR TITLE
Fix deprecations with ResourceOwnerInterface

### DIFF
--- a/src/Provider/OktaUser.php
+++ b/src/Provider/OktaUser.php
@@ -19,6 +19,9 @@ class OktaUser implements ResourceOwnerInterface
         $this->response = $response;
     }
 
+    /**
+     * @return mixed
+     */
     public function getId()
     {
         return $this->response['sub'];


### PR DESCRIPTION
Fix depractions

> Method "League\OAuth2\Client\Provider\ResourceOwnerInterface::getId()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Foxworth42\OAuth2\Client\Provider\OktaUser" now to avoid errors or add an explicit @return annotation to suppress this message.